### PR TITLE
Use uv instead of pip in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,15 +19,15 @@ jobs:
         python-version: [3.9]
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
-        python -m pip install -e .
+        python -m pip install uv
+        uv pip install --system -e .
     - name: Run pytest test_colors
       run: |
         cd ammico

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,16 +9,17 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: '3.9'
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0 # otherwise, you will failed to push refs to dest repo
     - name: install ammico
       run: |
-        pip install -e .
-        python -m pip install -r requirements-dev.txt
+        python -m pip install uv
+        uv pip install --system -e .
+        uv pip install --system -r requirements-dev.txt
     - name: set google auth
       uses: 'google-github-actions/auth@v0.4.0'
       with:


### PR DESCRIPTION
- `uv pip install --system` is a faster drop-in replacement for `pip install`
- bump github actions versions
