### PR TITLE
improve handling of exceptions for googletrans

### DIFF
--- a/ammico/test/test_text.py
+++ b/ammico/test/test_text.py
@@ -154,6 +154,16 @@ def test_check_add_space_after_full_stop(accepted):
     assert test_obj.subdict["text"] == "www. icanhascheezburger. com"
 
 
+def test_truncate_text(accepted):
+    test_obj = tt.TextDetector({}, accept_privacy=accepted)
+    test_obj.subdict["text"] = "I like cats and dogs."
+    test_obj._truncate_text()
+    assert test_obj.subdict["text"] == "I like cats and dogs."
+    test_obj.subdict["text"] = 20000 * "m"
+    test_obj._truncate_text()
+    assert test_obj.subdict["text"] == 5000 * "m"
+
+
 @pytest.mark.gcv
 def test_analyse_image(set_testdict, set_environ, accepted):
     for item in set_testdict:


### PR DESCRIPTION
- truncate text for googletrans to 5000 characters. At the moment, this is set globally, so the original text is truncated in the dict. However, one could also truncate a temporary variable and keep the original text at its original length (could result in a possibly longer text in the original than in the translation). This closes #240 
- skip translation if an error occurs, to avoid interruptions of the execution. This closes #237 