### PR TITLE
improve mem handling for video tests

### DIFF
--- a/ammico/test/conftest.py
+++ b/ammico/test/conftest.py
@@ -1,3 +1,4 @@
+import gc
 import os
 import pytest
 from ammico.model import MultimodalSummaryModel, MultimodalEmbeddingsModel
@@ -6,6 +7,15 @@ from ammico.multimodal_search import MultimodalSearch
 from unittest.mock import MagicMock
 import numpy as np
 import torch
+
+
+def _release_torch_memory() -> None:
+    gc.collect(2)
+    if torch.cuda.is_available():
+        try:
+            torch.cuda.empty_cache()
+        except Exception:
+            pass
 
 
 @pytest.fixture
@@ -62,13 +72,16 @@ def get_test_my_dict(get_path):
     return test_my_dict
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def model():
+    # module scope: one Qwen load per test file (not per test). Keep embedding-only tests in a
+    # separate module so this file never holds Qwen + Jina together via fixtures.
     m = MultimodalSummaryModel(device="cpu")
     try:
         yield m
     finally:
         m.close()
+        _release_torch_memory()
 
 
 @pytest.fixture
@@ -131,7 +144,7 @@ def mock_model():
     return MockMultimodalSummaryModel()
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def video_summary_model(model):
     vsm = VideoSummaryDetector(summary_model=model)
     try:
@@ -140,22 +153,26 @@ def video_summary_model(model):
         vsm.summary_model.close()
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def multimodal_embeddings_model_cpu():
     mem = MultimodalEmbeddingsModel(device="cpu")
     try:
         yield mem
     finally:
         mem.close()
+        _release_torch_memory()
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def multimodal_embeddings_model_cuda():
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is not available for multimodal embeddings tests")
     mem = MultimodalEmbeddingsModel(device="cuda")
     try:
         yield mem
     finally:
         mem.close()
+        _release_torch_memory()
 
 
 @pytest.fixture

--- a/ammico/test/test_image_summary.py
+++ b/ammico/test/test_image_summary.py
@@ -5,7 +5,8 @@ import pytest
 
 
 @pytest.mark.long
-def test_image_summary_detector(model, get_testdict):
+def test_image_summary_detector_summary_and_questions(model, get_testdict):
+    """One Qwen load for summary + VQA (avoids loading the VL model twice in this module)."""
     detector = ImageSummaryDetector(summary_model=model, subdict=get_testdict)
     results = detector.analyse_images_from_dict(analysis_type="summary")
     assert len(results) == 2
@@ -15,14 +16,10 @@ def test_image_summary_detector(model, get_testdict):
         assert isinstance(results[key]["caption"], str)
         assert len(results[key]["caption"]) > 0
 
-
-@pytest.mark.long
-def test_image_summary_detector_questions(model, get_testdict):
     list_of_questions = [
         "What is happening in the image?",
         "How many cars are in the image in total?",
     ]
-    detector = ImageSummaryDetector(summary_model=model, subdict=get_testdict)
     results = detector.analyse_images_from_dict(
         analysis_type="questions", list_of_questions=list_of_questions
     )

--- a/ammico/test/test_model.py
+++ b/ammico/test/test_model.py
@@ -3,17 +3,18 @@ from ammico.model import (
     MultimodalSummaryModel,
     AudioToTextModel,
 )
-from PIL import Image
-import numpy as np
-import torch
 
 
 @pytest.mark.long
-def test_model_init(model):
+def test_model_init_and_close_releases_resources(model):
     assert model.model is not None
     assert model.processor is not None
     assert model.tokenizer is not None
     assert model.device is not None
+    model.close()
+    assert model.model is None
+    assert model.processor is None
+    assert model.tokenizer is None
 
 
 @pytest.mark.long
@@ -28,14 +29,6 @@ def test_model_invalid_model_id():
         MultimodalSummaryModel(model_id="non_existent_model", device="cpu")
 
 
-@pytest.mark.long
-def test_free_resources():
-    model = MultimodalSummaryModel(device="cpu")
-    model.close()
-    assert model.model is None
-    assert model.processor is None
-
-
 def test_audio_to_text_model_invalid_language():
     with pytest.raises(ValueError):
         AudioToTextModel(language="xyz")
@@ -45,105 +38,3 @@ def test_audio_to_text_model_invalid_language():
 
     with pytest.raises(ValueError):
         AudioToTextModel(language="ha")  # not supported by whisperx align model
-
-
-def test_multimodal_embeddings_model_init(multimodal_embeddings_model_cpu):
-    assert multimodal_embeddings_model_cpu.model is not None
-    assert multimodal_embeddings_model_cpu.device == "cpu"
-    assert multimodal_embeddings_model_cpu.embedding_dim == 1024
-
-
-@pytest.mark.long
-def test_multimodal_embeddings_model_init_cuda(multimodal_embeddings_model_cuda):
-    assert multimodal_embeddings_model_cuda.model is not None
-    assert multimodal_embeddings_model_cuda.device == "cuda"
-    assert multimodal_embeddings_model_cuda.embedding_dim == 1024
-
-
-def test_multimodal_embeddings_model_encode_text(multimodal_embeddings_model_cpu):
-    texts = ["This is a test sentence.", "Another test sentence."]
-    embeddings = multimodal_embeddings_model_cpu.encode_text(texts)
-    assert isinstance(embeddings, np.ndarray)
-    assert embeddings.shape == (2, 1024)
-
-
-@pytest.mark.long
-def test_multimodal_embeddings_model_encode_text_cuda(multimodal_embeddings_model_cuda):
-    texts = ["This is a test sentence.", "Another test sentence."]
-    embeddings = multimodal_embeddings_model_cuda.encode_text(texts)
-    assert isinstance(embeddings, torch.Tensor)
-    assert embeddings.shape == (2, 1024)
-
-
-def test_multimodal_embeddings_model_encode_text_truncate(
-    multimodal_embeddings_model_cpu,
-):
-    texts = ["This is a test sentence."]
-    embeddings = multimodal_embeddings_model_cpu.encode_text(texts, truncate_dim=128)
-    assert embeddings.shape == (1, 128)
-
-
-@pytest.mark.long
-def test_multimodal_embeddings_model_encode_text_truncate_cuda(
-    multimodal_embeddings_model_cuda,
-):
-    texts = ["This is a test sentence."]
-    embeddings = multimodal_embeddings_model_cuda.encode_text(texts, truncate_dim=128)
-    assert embeddings.shape == (1, 128)
-
-
-def test_multimodal_embeddings_model_encode_text_invalid_truncate(
-    multimodal_embeddings_model_cpu,
-):
-    texts = ["This is a test sentence."]
-    with pytest.raises(ValueError):
-        multimodal_embeddings_model_cpu.encode_text(texts, truncate_dim=32)
-
-
-def test_multimodal_embeddings_model_encode_image(multimodal_embeddings_model_cpu):
-    image = Image.new("RGB", (224, 224))
-    embeddings = multimodal_embeddings_model_cpu.encode_image(image)
-    assert isinstance(embeddings, np.ndarray)
-    assert embeddings.shape == (1, 1024)
-
-
-@pytest.mark.long
-def test_multimodal_embeddings_model_encode_image_cuda(
-    multimodal_embeddings_model_cuda,
-):
-    image = Image.new("RGB", (224, 224))
-    embeddings = multimodal_embeddings_model_cuda.encode_image(image)
-    assert isinstance(embeddings, torch.Tensor)
-    assert embeddings.shape == (1, 1024)
-
-
-def test_multimodal_embeddings_model_encode_image_truncate(
-    multimodal_embeddings_model_cpu,
-):
-    image = Image.new("RGB", (224, 224))
-    embeddings = multimodal_embeddings_model_cpu.encode_image(image, truncate_dim=128)
-    assert embeddings.shape == (1, 128)
-
-
-@pytest.mark.long
-def test_multimodal_embeddings_model_encode_image_truncate_cuda(
-    multimodal_embeddings_model_cuda,
-):
-    image = Image.new("RGB", (224, 224))
-    embeddings = multimodal_embeddings_model_cuda.encode_image(image, truncate_dim=128)
-    assert embeddings.shape == (1, 128)
-
-
-def test_multimodal_embeddings_model_encode_image_invalid_truncate(
-    multimodal_embeddings_model_cpu,
-):
-    image = Image.new("RGB", (224, 224))
-    with pytest.raises(ValueError):
-        multimodal_embeddings_model_cpu.encode_image(image, truncate_dim=32)
-
-
-def test_multimodal_embeddings_model_encode_image_invalid_input(
-    multimodal_embeddings_model_cpu,
-):
-    with pytest.raises(ValueError):
-        multimodal_embeddings_model_cpu.encode_image("not_an_image")

--- a/ammico/test/test_multimodal_embeddings_model.py
+++ b/ammico/test/test_multimodal_embeddings_model.py
@@ -1,0 +1,106 @@
+import pytest
+from PIL import Image
+import numpy as np
+import torch
+
+
+def test_multimodal_embeddings_model_init(multimodal_embeddings_model_cpu):
+    assert multimodal_embeddings_model_cpu.model is not None
+    assert multimodal_embeddings_model_cpu.device == "cpu"
+    assert multimodal_embeddings_model_cpu.embedding_dim == 1024
+
+
+@pytest.mark.long
+def test_multimodal_embeddings_model_init_cuda(multimodal_embeddings_model_cuda):
+    assert multimodal_embeddings_model_cuda.model is not None
+    assert multimodal_embeddings_model_cuda.device == "cuda"
+    assert multimodal_embeddings_model_cuda.embedding_dim == 1024
+
+
+def test_multimodal_embeddings_model_encode_text(multimodal_embeddings_model_cpu):
+    texts = ["This is a test sentence.", "Another test sentence."]
+    embeddings = multimodal_embeddings_model_cpu.encode_text(texts)
+    assert isinstance(embeddings, np.ndarray)
+    assert embeddings.shape == (2, 1024)
+
+
+@pytest.mark.long
+def test_multimodal_embeddings_model_encode_text_cuda(multimodal_embeddings_model_cuda):
+    texts = ["This is a test sentence.", "Another test sentence."]
+    embeddings = multimodal_embeddings_model_cuda.encode_text(texts)
+    assert isinstance(embeddings, torch.Tensor)
+    assert embeddings.shape == (2, 1024)
+
+
+def test_multimodal_embeddings_model_encode_text_truncate(
+    multimodal_embeddings_model_cpu,
+):
+    texts = ["This is a test sentence."]
+    embeddings = multimodal_embeddings_model_cpu.encode_text(texts, truncate_dim=128)
+    assert embeddings.shape == (1, 128)
+
+
+@pytest.mark.long
+def test_multimodal_embeddings_model_encode_text_truncate_cuda(
+    multimodal_embeddings_model_cuda,
+):
+    texts = ["This is a test sentence."]
+    embeddings = multimodal_embeddings_model_cuda.encode_text(texts, truncate_dim=128)
+    assert embeddings.shape == (1, 128)
+
+
+def test_multimodal_embeddings_model_encode_text_invalid_truncate(
+    multimodal_embeddings_model_cpu,
+):
+    texts = ["This is a test sentence."]
+    with pytest.raises(ValueError):
+        multimodal_embeddings_model_cpu.encode_text(texts, truncate_dim=32)
+
+
+def test_multimodal_embeddings_model_encode_image(multimodal_embeddings_model_cpu):
+    image = Image.new("RGB", (224, 224))
+    embeddings = multimodal_embeddings_model_cpu.encode_image(image)
+    assert isinstance(embeddings, np.ndarray)
+    assert embeddings.shape == (1, 1024)
+
+
+@pytest.mark.long
+def test_multimodal_embeddings_model_encode_image_cuda(
+    multimodal_embeddings_model_cuda,
+):
+    image = Image.new("RGB", (224, 224))
+    embeddings = multimodal_embeddings_model_cuda.encode_image(image)
+    assert isinstance(embeddings, torch.Tensor)
+    assert embeddings.shape == (1, 1024)
+
+
+def test_multimodal_embeddings_model_encode_image_truncate(
+    multimodal_embeddings_model_cpu,
+):
+    image = Image.new("RGB", (224, 224))
+    embeddings = multimodal_embeddings_model_cpu.encode_image(image, truncate_dim=128)
+    assert embeddings.shape == (1, 128)
+
+
+@pytest.mark.long
+def test_multimodal_embeddings_model_encode_image_truncate_cuda(
+    multimodal_embeddings_model_cuda,
+):
+    image = Image.new("RGB", (224, 224))
+    embeddings = multimodal_embeddings_model_cuda.encode_image(image, truncate_dim=128)
+    assert embeddings.shape == (1, 128)
+
+
+def test_multimodal_embeddings_model_encode_image_invalid_truncate(
+    multimodal_embeddings_model_cpu,
+):
+    image = Image.new("RGB", (224, 224))
+    with pytest.raises(ValueError):
+        multimodal_embeddings_model_cpu.encode_image(image, truncate_dim=32)
+
+
+def test_multimodal_embeddings_model_encode_image_invalid_input(
+    multimodal_embeddings_model_cpu,
+):
+    with pytest.raises(ValueError):
+        multimodal_embeddings_model_cpu.encode_image("not_an_image")

--- a/ammico/test/test_multimodal_search.py
+++ b/ammico/test/test_multimodal_search.py
@@ -93,7 +93,7 @@ def test_multimodal_search_combined_query(get_path):
         results = mms.multimodal_batch_search(queries=queries, top_k=3)
 
         assert len(results) == 2
-        for query_idx, (items, scores) in enumerate(results):
+        for items, scores in results:
             assert len(items) > 0
             assert len(items) == len(scores)
 

--- a/ammico/test/test_multimodal_search.py
+++ b/ammico/test/test_multimodal_search.py
@@ -83,19 +83,22 @@ def test_multimodal_search_image_query(multimodal_search_mock, tmp_path):
 @pytest.mark.long
 def test_multimodal_search_combined_query(get_path):
     model = MultimodalEmbeddingsModel(device="cpu")
-    mms = MultimodalSearch(model=model)
-    mms.index_images(images=get_path, save_embeddings_and_indexes=False)
-    queries = [
-        {"text": "A person wearing a mask"},
-        {"image": Path(get_path) / "IMG_2809.png"},
-    ]
-    results = mms.multimodal_batch_search(queries=queries, top_k=3)
+    try:
+        mms = MultimodalSearch(model=model)
+        mms.index_images(images=get_path, save_embeddings_and_indexes=False)
+        queries = [
+            {"text": "A person wearing a mask"},
+            {"image": Path(get_path) / "IMG_2809.png"},
+        ]
+        results = mms.multimodal_batch_search(queries=queries, top_k=3)
 
-    assert len(results) == 2
-    for query_idx, (items, scores) in enumerate(results):
-        assert len(items) > 0
-        assert len(items) == len(scores)
+        assert len(results) == 2
+        for query_idx, (items, scores) in enumerate(results):
+            assert len(items) > 0
+            assert len(items) == len(scores)
 
-    assert any("pexels-maksgelatin-4750169.jpg" in item for item in results[0][0])
-    assert any("IMG_2809.png" in item for item in results[1][0])
-    assert any("IMG_3758.png" in item for item in results[1][0])
+        assert any("pexels-maksgelatin-4750169.jpg" in item for item in results[0][0])
+        assert any("IMG_2809.png" in item for item in results[1][0])
+        assert any("IMG_3758.png" in item for item in results[1][0])
+    finally:
+        model.close()

--- a/ammico/test/test_video_vqa.py
+++ b/ammico/test/test_video_vqa.py
@@ -58,7 +58,8 @@ def test_analyse_videos_from_dict_summary_and_questions(
     video_summary_model, get_video_testdict
 ):
     video_summary_model.subdict = get_video_testdict
-    video_summary_model.audio_model = AudioToTextModel(model_size="large", device="cpu")
+    # "small" keeps RAM down alongside Qwen on CPU; "large" can OOM on typical dev machines.
+    video_summary_model.audio_model = AudioToTextModel(model_size="small", device="cpu")
     questions = ["When and where the video was recorded?"]
     results = video_summary_model.analyse_videos_from_dict(
         analysis_type="summary_and_questions", list_of_questions=questions


### PR DESCRIPTION
- make tests reuse or release model
- test embeddings separately
- peak mem usage on CPU ony: 18.3 GB for one small video