### PR TITLE
Fix issue with long static video segments.

### DIFF
--- a/ammico/test/conftest.py
+++ b/ammico/test/conftest.py
@@ -97,14 +97,18 @@ def mock_model():
         def apply_chat_template(self, messages, **kwargs):
             return "processed_text"
 
-        def __call__(self, text, images, **kwargs):
+        def __call__(self, text=None, images=None, **kwargs):
             """Mock processing that returns tensor-like inputs."""
             batch_size = len(text) if isinstance(text, list) else 1
-            return {
+            result = {
                 "input_ids": torch.randint(0, 1000, (batch_size, 10)),
-                "pixel_values": torch.randn(batch_size, 3, 224, 224),
                 "attention_mask": torch.ones(batch_size, 10),
             }
+
+            if images is not None:
+                result["pixel_values"] = torch.randn(batch_size, 3, 224, 224)
+
+            return result
 
     class MockTokenizer:
         """Mock tokenizer that mimics AutoTokenizer behavior."""

--- a/ammico/test/test_video_vqa.py
+++ b/ammico/test/test_video_vqa.py
@@ -420,3 +420,210 @@ def test_reassign_video_timestamps_segment_does_not_overlap_video(
     video_summ._reassign_video_timestamps_to_segments(segments, video_segs)
 
     assert segments[0]["video_frame_timestamps"] == []
+
+
+def test_make_captions_for_subclips_with_frame_timestamp(
+    mock_model,
+    monkeypatch,
+    tmp_path,
+):
+    """This tests the case where the segment has frame timestamps that fall within its time range.
+    In this case, the method should use those frame timestamps to generate captions for the segment, and the resulting summary bullets should reference the specific timestamps of the frames."""
+
+    video_file = tmp_path / "video.mp4"
+    video_file.write_bytes(b"fake video content")
+
+    video_summ = VideoSummaryDetector(
+        summary_model=mock_model,
+        audio_model=None,
+        subdict={},
+    )
+
+    def fake_extract_frame_timestamps_from_clip(filename):
+        return {
+            "segments": [
+                {
+                    "type": "video_scene",
+                    "start_time": 10.0,
+                    "end_time": 18.0,
+                    "duration": 8.0,
+                    "frame_timestamps": [10.0, 14.0, 18.0],
+                }
+            ],
+            "video_meta": {
+                "width": 1920,
+                "height": 1080,
+            },
+        }
+
+    def fake_merge_audio_visual_boundaries(audio_segs, video_segs):
+        return [
+            {
+                "start_time": 10.0,
+                "end_time": 18.0,
+                "duration": 8.0,
+                "audio_phrases": [],
+                "video_scenes": video_segs,
+                "video_frame_timestamps": [10.0, 14.0, 18.0],
+                "summary_bullets": [
+                    "- [10.000s] A presenter is visible.",
+                ],
+                "vqa_bullets": [],
+            }
+        ]
+
+    def fake_make_captions_from_extracted_frames(
+        filename,
+        merged_segments,
+        video_meta,
+        list_of_questions=None,
+    ):
+        merged_segments[0]["summary_bullets"] = [
+            "- [10.000s] A presenter is visible.",
+        ]
+        merged_segments[0]["vqa_bullets"] = []
+
+    def fake_generate_from_processor_inputs(*args, **kwargs):
+        return [
+            "A presenter explains the project timeline.",
+        ]
+
+    monkeypatch.setattr(
+        video_summ,
+        "_extract_frame_timestamps_from_clip",
+        fake_extract_frame_timestamps_from_clip,
+    )
+    monkeypatch.setattr(
+        video_summ,
+        "merge_audio_visual_boundaries",
+        fake_merge_audio_visual_boundaries,
+    )
+    monkeypatch.setattr(
+        video_summ,
+        "_make_captions_from_extracted_frames",
+        fake_make_captions_from_extracted_frames,
+    )
+    monkeypatch.setattr(
+        video_summ,
+        "_generate_from_processor_inputs",
+        fake_generate_from_processor_inputs,
+    )
+
+    result = video_summ.make_captions_for_subclips(
+        {"filename": str(video_file)},
+    )
+
+    assert result == [
+        {
+            "start_time": 10.0,
+            "end_time": 18.0,
+            "summary_bullets": [
+                "- [10.000s] A presenter explains the project timeline.",
+            ],
+            "vqa_bullets": [],
+        }
+    ]
+
+
+def test_make_captions_for_subclips_without_frame_timestamp(
+    mock_model,
+    monkeypatch,
+    tmp_path,
+):
+    """This tests the case where the segment does not have any visual timestamps that fall within its time range.
+    In this case, the method should not fail, but it should still generate captions based on the audio content."""
+    video_file = tmp_path / "video.mp4"
+    video_file.write_bytes(b"fake video content")
+
+    video_summ = VideoSummaryDetector(
+        summary_model=mock_model,
+        audio_model=None,
+        subdict={},
+    )
+
+    def fake_extract_frame_timestamps_from_clip(filename):
+        return {
+            "segments": [
+                {
+                    "type": "video_scene",
+                    "start_time": 35.0,
+                    "end_time": 38.0,
+                    "duration": 3.0,
+                    "frame_timestamps": [],
+                }
+            ],
+            "video_meta": {
+                "width": 1920,
+                "height": 1080,
+            },
+        }
+
+    def fake_merge_audio_visual_boundaries(audio_segs, video_segs):
+        return [
+            {
+                "start_time": 35.0,
+                "end_time": 38.0,
+                "duration": 3.0,
+                "audio_phrases": [
+                    {
+                        "start_time": 35.2,
+                        "end_time": 37.7,
+                        "text": "All stages of the project timeline are shown in a chart.",
+                        "duration": 2.5,
+                    }
+                ],
+                "video_scenes": video_segs,
+                "video_frame_timestamps": [],
+                "summary_bullets": [],
+                "vqa_bullets": [],
+            }
+        ]
+
+    def fake_make_captions_from_extracted_frames(
+        filename,
+        merged_segments,
+        video_meta,
+        list_of_questions=None,
+    ):
+        return None
+
+    def fake_generate_from_processor_inputs(*args, **kwargs):
+        return [
+            "The presenter introduces a chart about the project timeline.",
+        ]
+
+    monkeypatch.setattr(
+        video_summ,
+        "_extract_frame_timestamps_from_clip",
+        fake_extract_frame_timestamps_from_clip,
+    )
+    monkeypatch.setattr(
+        video_summ,
+        "merge_audio_visual_boundaries",
+        fake_merge_audio_visual_boundaries,
+    )
+    monkeypatch.setattr(
+        video_summ,
+        "_make_captions_from_extracted_frames",
+        fake_make_captions_from_extracted_frames,
+    )
+    monkeypatch.setattr(
+        video_summ,
+        "_generate_from_processor_inputs",
+        fake_generate_from_processor_inputs,
+    )
+
+    result = video_summ.make_captions_for_subclips(
+        {"filename": str(video_file)},
+    )
+
+    assert result == [
+        {
+            "start_time": 35.0,
+            "end_time": 38.0,
+            "summary_bullets": [
+                "- [36.500s] The presenter introduces a chart about the project timeline.",
+            ],
+            "vqa_bullets": [],
+        }
+    ]

--- a/ammico/test/test_video_vqa.py
+++ b/ammico/test/test_video_vqa.py
@@ -311,7 +311,7 @@ def test_extract_frame_timestamps_long_scene(
 
     gaps = [right - left for left, right in zip(timestamps, timestamps[1:])]
 
-    assert all(gap <= 30.0 for gap in gaps)
+    assert all(gap <= 30.0 + 1e-4 for gap in gaps)
 
 
 def test_extract_frame_timestamps_short_scene_keeps_existing_behavior(

--- a/ammico/test/test_video_vqa.py
+++ b/ammico/test/test_video_vqa.py
@@ -132,7 +132,10 @@ def test_extract_frame_timestamps_from_clip(mock_model, get_video_testdict):
         assert "frame_timestamps" in seg
         assert isinstance(seg["frame_timestamps"], list)
         assert all(isinstance(t, float) for t in seg["frame_timestamps"])
-        assert seg["end_time"] - seg["start_time"] <= 20.0
+        assert len(seg["frame_timestamps"]) >= 1
+        eps = 1e-5
+        for timestamp in seg["frame_timestamps"]:
+            assert seg["start_time"] - eps <= timestamp <= seg["end_time"] + eps
 
 
 def test_merge_audio_visual_boundaries_type_and_size(mock_model):
@@ -268,3 +271,85 @@ def test_combine_visual_frames_by_time(mock_model):
     assert combined[2]["end_time"] == 60.0
     assert combined[3]["start_time"] == 60.0
     assert combined[3]["end_time"] == 80.0
+
+
+def test_extract_frame_timestamps_long_scene(
+    mock_model,
+    monkeypatch,
+):
+    video_summ = VideoSummaryDetector(summary_model=mock_model)
+
+    def fake_detect_scene_cuts(filename):
+        return {
+            "segments": [
+                {
+                    "type": "video_scene",
+                    "start_time": 0.0,
+                    "end_time": 300.0,
+                    "duration": 300.0,
+                }
+            ],
+            "video_meta": {
+                "width": 1920,
+                "height": 1080,
+            },
+        }
+
+    monkeypatch.setattr(
+        video_summ,
+        "_detect_scene_cuts",
+        fake_detect_scene_cuts,
+    )
+
+    result = video_summ._extract_frame_timestamps_from_clip("fake.mp4")
+
+    timestamps = result["segments"][0]["frame_timestamps"]
+
+    assert len(timestamps) == 11
+    assert timestamps[0] == pytest.approx(0.0)
+    assert timestamps[-1] == pytest.approx(300.0)
+
+    gaps = [right - left for left, right in zip(timestamps, timestamps[1:])]
+
+    assert all(gap <= 30.0 for gap in gaps)
+
+
+def test_extract_frame_timestamps_short_scene_keeps_existing_behavior(
+    mock_model,
+    monkeypatch,
+):
+    video_summ = VideoSummaryDetector(summary_model=mock_model)
+
+    def fake_detect_scene_cuts(filename):
+        return {
+            "segments": [
+                {
+                    "type": "video_scene",
+                    "start_time": 10.0,
+                    "end_time": 20.0,
+                    "duration": 10.0,
+                }
+            ],
+            "video_meta": {
+                "width": 1280,
+                "height": 720,
+            },
+        }
+
+    monkeypatch.setattr(
+        video_summ,
+        "_detect_scene_cuts",
+        fake_detect_scene_cuts,
+    )
+
+    result = video_summ._extract_frame_timestamps_from_clip("fake.mp4")
+
+    timestamps = result["segments"][0]["frame_timestamps"]
+
+    assert len(timestamps) == 4
+    assert timestamps[0] == pytest.approx(10.0)
+    assert timestamps[-1] == pytest.approx(20.0)
+    assert result["video_meta"] == {
+        "width": 1280,
+        "height": 720,
+    }

--- a/ammico/test/test_video_vqa.py
+++ b/ammico/test/test_video_vqa.py
@@ -353,3 +353,70 @@ def test_extract_frame_timestamps_short_scene_keeps_existing_behavior(
         "width": 1280,
         "height": 720,
     }
+
+
+def test_reassign_video_timestamps_segment_has_no_sampled_frame(
+    mock_model,
+):
+    """This tests the case where a segment overlaps with a video scene, but the scene's frame timestamps do not include any frames that fall within the segment's time range. In this case, the method should add a fallback timestamp at the midpoint of the segment."""
+    video_summ = VideoSummaryDetector(summary_model=mock_model)
+
+    segments = [
+        {
+            "start_time": 5.0,
+            "end_time": 7.0,
+            "duration": 2.0,
+            "audio_phrases": [
+                {
+                    "start_time": 5.2,
+                    "end_time": 6.8,
+                    "text": "Short phrase.",
+                    "duration": 1.6,
+                }
+            ],
+            "video_scenes": [],
+        }
+    ]
+
+    video_segs = [
+        {
+            "start_time": 0.0,
+            "end_time": 60.0,
+            "duration": 60.0,
+            "frame_timestamps": [0.0, 30.0, 60.0],
+        }
+    ]
+
+    video_summ._reassign_video_timestamps_to_segments(segments, video_segs)
+
+    assert segments[0]["video_frame_timestamps"] == [6.0]
+
+
+def test_reassign_video_timestamps_segment_does_not_overlap_video(
+    mock_model,
+):
+    """This tests the case where a segment does not overlap with any video scenes at all. In this case, the method should leave the "video_frame_timestamps" list empty, since there are no relevant frames to assign to the segment."""
+    video_summ = VideoSummaryDetector(summary_model=mock_model)
+
+    segments = [
+        {
+            "start_time": 70.0,
+            "end_time": 75.0,
+            "duration": 5.0,
+            "audio_phrases": [],
+            "video_scenes": [],
+        }
+    ]
+
+    video_segs = [
+        {
+            "start_time": 0.0,
+            "end_time": 60.0,
+            "duration": 60.0,
+            "frame_timestamps": [0.0, 30.0, 60.0],
+        }
+    ]
+
+    video_summ._reassign_video_timestamps_to_segments(segments, video_segs)
+
+    assert segments[0]["video_frame_timestamps"] == []

--- a/ammico/video_summary.py
+++ b/ammico/video_summary.py
@@ -437,7 +437,7 @@ class VideoSummaryDetector(AnalysisMethod):
             start_time = seg["start_time"]
             end_time = seg["end_time"]
             sample_times = torch.linspace(
-                start_time, end_time, steps=frame_rate_per_clip, dtype=torch.float32
+                start_time, end_time, steps=int(frame_rate_per_clip), dtype=torch.float32
             )
             seg["frame_timestamps"] = sample_times.tolist()
 

--- a/ammico/video_summary.py
+++ b/ammico/video_summary.py
@@ -428,16 +428,19 @@ class VideoSummaryDetector(AnalysisMethod):
                 frame_rate_per_clip = 2.0
             elif seg["duration"] > max_seconds_between_frames:
                 frame_rate_per_clip = max(
-                1,
-                int(math.ceil(seg["duration"] / max_seconds_between_frames)),
-            )
+                    1,
+                    int(math.ceil(seg["duration"] / max_seconds_between_frames)),
+                )
             else:
                 frame_rate_per_clip = base_frames_per_clip
 
             start_time = seg["start_time"]
             end_time = seg["end_time"]
             sample_times = torch.linspace(
-                start_time, end_time, steps=int(frame_rate_per_clip), dtype=torch.float32
+                start_time,
+                end_time,
+                steps=int(frame_rate_per_clip),
+                dtype=torch.float32,
             )
             seg["frame_timestamps"] = sample_times.tolist()
 
@@ -460,32 +463,54 @@ class VideoSummaryDetector(AnalysisMethod):
             None
         """
 
-        boundary_margin = 0.5
         eps = 1e-6
-
         video_list = list(video_segs)
+
         for seg in segments:
             seg_start = seg["start_time"]
             seg_end = seg["end_time"]
 
             merged_timestamps: List[float] = []
+            fallback_candidates: List[Tuple[float, float]] = []
             for vscene in video_list:
                 if "frame_timestamps" not in vscene:
                     raise ValueError("Video scene missing 'frame_timestamps' key.")
 
+                v_start = float(vscene["start_time"])
+                v_end = float(vscene["end_time"])
+
+                overlap_start = max(seg_start, v_start)
+                overlap_end = min(seg_end, v_end)
+
+                has_overlap = overlap_end + eps >= overlap_start
+
+                if has_overlap:
+                    fallback_candidates.append((overlap_start, overlap_end))
+
                 contrib = [
                     float(t)
                     for t in vscene["frame_timestamps"]
-                    if (t + eps) >= (seg_start - boundary_margin)
-                    and (t - eps) <= (seg_end + boundary_margin)
-                    and (t + eps) >= seg_start
-                    and (t - eps) <= seg_end
+                    if (t + eps) >= seg_start and (t - eps) <= seg_end
                 ]
+
                 if contrib:
                     merged_timestamps.extend(contrib)
 
-            # dedupe & sort
-            seg["video_frame_timestamps"] = sorted(set(merged_timestamps))
+            if not merged_timestamps and fallback_candidates:
+                best_start, best_end = max(
+                    fallback_candidates,
+                    key=lambda bounds: bounds[1] - bounds[0],
+                )
+                fallback_ts = (best_start + best_end) / 2.0
+                merged_timestamps.append(fallback_ts)
+
+            seg["video_frame_timestamps"] = sorted(
+                {
+                    round(float(t), 6)
+                    for t in merged_timestamps
+                    if math.isfinite(float(t))
+                }
+            )
 
     def _combine_visual_frames_by_time(
         self,

--- a/ammico/video_summary.py
+++ b/ammico/video_summary.py
@@ -983,8 +983,17 @@ class VideoSummaryDetector(AnalysisMethod):
                 [prompt_text],
                 self.summary_model.tokenizer,
             )
-            for t, c in zip(frame_timestamps, final_outputs):
-                collected.append((float(t), c))
+            clip_text = final_outputs[0].strip() if final_outputs else ""
+
+            if frame_timestamps:
+                clip_timestamp = float(frame_timestamps[0])
+            else:
+                clip_timestamp = (
+                    float(seg["start_time"]) + float(seg["end_time"])
+                ) / 2.0
+
+            if clip_text:
+                collected.append((clip_timestamp, clip_text))
 
             collected.sort(key=lambda x: x[0])
             bullets_summary, bullets_vqa = _categorize_outputs(

--- a/ammico/video_summary.py
+++ b/ammico/video_summary.py
@@ -429,7 +429,7 @@ class VideoSummaryDetector(AnalysisMethod):
             elif seg["duration"] > max_seconds_between_frames:
                 frame_rate_per_clip = max(
                     1,
-                    int(math.ceil(seg["duration"] / max_seconds_between_frames)),
+                    int(math.ceil(seg["duration"] / max_seconds_between_frames)) + 1,
                 )
             else:
                 frame_rate_per_clip = base_frames_per_clip

--- a/ammico/video_summary.py
+++ b/ammico/video_summary.py
@@ -419,22 +419,25 @@ class VideoSummaryDetector(AnalysisMethod):
             List of segments with 'start_time', 'end_time', and 'frame_timestamps'
         """
         base_frames_per_clip = 4.0
+        max_seconds_between_frames = 30.0
         result = self._detect_scene_cuts(filename)
         segments = result["segments"]
         video_meta = result["video_meta"]
         for seg in segments:
             if seg["duration"] < 2.0:
                 frame_rate_per_clip = 2.0
-            elif seg["duration"] > 20.0:
-                frame_rate_per_clip = 6.0
+            elif seg["duration"] > max_seconds_between_frames:
+                frame_rate_per_clip = max(
+                1,
+                int(math.ceil(seg["duration"] / max_seconds_between_frames)),
+            )
             else:
                 frame_rate_per_clip = base_frames_per_clip
 
             start_time = seg["start_time"]
             end_time = seg["end_time"]
-            n_samples = max(1, int(frame_rate_per_clip))
             sample_times = torch.linspace(
-                start_time, end_time, steps=n_samples, dtype=torch.float32
+                start_time, end_time, steps=frame_rate_per_clip, dtype=torch.float32
             )
             seg["frame_timestamps"] = sample_times.tolist()
 


### PR DESCRIPTION
This should fix #285 .
 3 related sub-problems were found and fixed in 3 different functions:

1.  `_extract_frame_timestamps_from_clip`  -  the number of frames in each segment was fixed, which caused issues when working with long segments (the function was designed for short videos). Fixed by adding a flexible amount of frames per segment - at least one for every 30 seconds.
2.  `_reassign_video_timestamps_to_segments` - this was the root of the problem.  In some cases it might return no timestamps, which lead to failure, described in #285 . The updated version includes some extra checks to resolve  the issue. Now, if a merged segment overlaps a video scene, it should receive at least one valid visual timestamp.
3. `make_captions_for_subclips` - there was one fragile part in the function’s logic that could lead to information loss in rare cases.  The small fix should protect against this problem and make the function more robust.

Also, I implemented couple of tests for each of the fix, presented in this PR.